### PR TITLE
Fix violation of strict weak ordering when sorting clusters by index

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rclusterpp
 Type: Package
 Title: Linkable C++ clustering
-Version: 0.2.3
+Version: 0.2.4
 Date: 2013-09-23
 Authors@R: c(person("Michael Linderman",role="aut",email="michael.d.linderman@gmail.com"),
 	     person("Robert Bruggner",role="cre",email="rbruggner@gmail.com"))

--- a/inst/doc/Rclusterpp.Rnw
+++ b/inst/doc/Rclusterpp.Rnw
@@ -22,7 +22,7 @@
 \newcommand{\code}[1]{\texttt{#1}}
 
 <<version,echo=FALSE,print=FALSE>>=
-prettyVersion <- packageDescription("RcppEigen")$Version
+prettyVersion <- packageDescription("Rclusterpp")$Version
 prettyDate <- format(Sys.Date(), "%B %e, %Y")
 @
 

--- a/inst/include/Rclusterpp/algorithm.h
+++ b/inst/include/Rclusterpp/algorithm.h
@@ -131,9 +131,12 @@ namespace Rclusterpp {
 		// from -1 .. -initial_clusters, followed by the agglomerated clusters sorted by
 		// increasing disimilarity.
 		
-		std::partition(clusters.begin(), clusters.end(), std::mem_fun(&cluster_type::initial));
-		std::sort(clusters.begin(), clusters.begin()+initial_clusters, std::not2(std::ptr_fun(&compare_id<cluster_type>))); 
-		std::sort(clusters.begin() + initial_clusters, clusters.end(), std::ptr_fun(&compare_disimilarity<cluster_type>)); 
+    // Note, sort requires strict weak ordering and will fail in a data dependent way
+    // if the comparison function does not satisfy that requirement
+    
+		typename clusters_type::iterator part = std::partition(clusters.begin(), clusters.end(), std::mem_fun(&cluster_type::initial));
+    std::sort(clusters.begin(), part, &compare_id<cluster_type>); 
+		std::sort(part, clusters.end(), std::ptr_fun(&compare_disimilarity<cluster_type>)); 
 
 		for (size_t i=initial_clusters; i<result_clusters; i++) {
 			clusters[i]->set_id(i - initial_clusters + 1);  // Use R hclust 1-indexed convention for Id's

--- a/inst/include/Rclusterpp/cluster.h
+++ b/inst/include/Rclusterpp/cluster.h
@@ -43,7 +43,8 @@ namespace Rclusterpp {
 			distance_type disimilarity() const { return disimilarity_; }
 	
 		private:
-			
+			Cluster() {}
+      
 			ssize_t id_;
 			size_t  idx_;
 			size_t  size_;
@@ -57,7 +58,7 @@ namespace Rclusterpp {
 
 	template<class Cluster>
 	inline bool compare_id(Cluster const* l, Cluster const* r) {
-		return l->id() < r->id();
+		return l->id() > r->id();
 	}
 
 	template<class Cluster>
@@ -167,7 +168,7 @@ namespace Rclusterpp {
 			typedef typename underlying_type::const_iterator  const_iterator;
 			typedef typename underlying_type::size_type       size_type;
 		
-			ClusterVector(size_t n) : initial_(n), clusters_(n) {}
+			ClusterVector(size_t n) : initial_(n), clusters_(n, 0) {}
 			
 			~ClusterVector() {
 				for (iterator i=begin(), e=end(); i!=e; ++i)
@@ -205,12 +206,11 @@ namespace Rclusterpp {
 
 		private:
 
-			ClusterVector() : clusters_() {}
+			ClusterVector() {}
 			explicit ClusterVector(const ClusterVector& v);
 
 			size_t          initial_;  // Number of initial clusters
 			underlying_type clusters_;
-
 	};
 
 	


### PR DESCRIPTION
This fixes an insidious error in sorting that was leading to a segfault on OSX Mavericks with clang.