### PR TITLE
Remove warning message passing multi-class object to Rclusterpp.hclust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Provide flexible native clustering routines that can be
 License: MIT + file LICENSE
 Depends: R (>= 2.12.0), Rcpp (>= 0.10.4)
 LinkingTo: Rcpp, RcppEigen
-Suggests: RUnit, rbenchmark, fastcluster, inline, knitr
+Suggests: RUnit, rbenchmark, fastcluster, inline, knitr, markdown
 URL: https://github.com/nolanlab/Rclusterpp
 BugReports: https://github.com/nolanlab/Rclusterpp/issues
 NeedsCompilation: yes

--- a/R/Rclusterpp.hclust.R
+++ b/R/Rclusterpp.hclust.R
@@ -20,7 +20,7 @@ Rclusterpp.hclust <- function(x, method="ward", members=NULL, distance="euclidea
   if (method == -1) 
     stop("Ambiguous clustering method")
 
-	if (class(x) == "dist") {
+	if (any(class(x)=="dist")) {
 		dist.method = attributes(x)$method
 		labels      = attributes(x)$Labels
 


### PR DESCRIPTION
Small patch to remove warning message when you pass a matrix to Rclusterpp.hclust.
