### PR TITLE
Update C++ functions deprecated in C++11

### DIFF
--- a/Rclusterpp.Rproj
+++ b/Rclusterpp.Rproj
@@ -14,5 +14,5 @@ LaTeX: pdfLaTeX
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageInstallArgs: --no-multiarch
+PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran

--- a/inst/include/Rclusterpp/algorithm.h
+++ b/inst/include/Rclusterpp/algorithm.h
@@ -1,8 +1,6 @@
 #ifndef RCLUSTERP_ALGORITHM_H
 #define RCLUSTERP_ALGORITHM_H
 
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <limits>
 #include <utility>
 #include <algorithm>
@@ -138,9 +136,9 @@ namespace Rclusterpp {
     // Note, sort requires strict weak ordering and will fail in a data dependent way
     // if the comparison function does not satisfy that requirement
     
-		typename clusters_type::iterator part = std::stable_partition(clusters.begin(), clusters.end(), std::mem_fun(&cluster_type::initial));
+		typename clusters_type::iterator part = std::stable_partition(clusters.begin(), clusters.end(), std::mem_fn(&cluster_type::initial));
     std::sort(clusters.begin(), part, &compare_id<cluster_type>); 
-		std::stable_sort(part, clusters.end(), std::ptr_fun(&compare_disimilarity<cluster_type>)); 
+		std::stable_sort(part, clusters.end(), &compare_disimilarity<cluster_type>); 
 
 		for (size_t i=initial_clusters; i<result_clusters; i++) {
 			clusters[i]->set_id(i - initial_clusters + 1);  // Use R hclust 1-indexed convention for Id's

--- a/inst/include/Rclusterpp/hclust.h
+++ b/inst/include/Rclusterpp/hclust.h
@@ -52,9 +52,9 @@ namespace Rclusterpp {
 		typename Clusters::const_iterator last  = clusters.end();
 		typename Clusters::const_iterator first = last - hclust.agglomerations();
 
-		std::transform(first, last, hclust.merge.column(0).begin(), std::mem_fun(&cluster_type::parent1Id));
-		std::transform(first, last, hclust.merge.column(1).begin(), std::mem_fun(&cluster_type::parent2Id));
-		std::transform(first, last, hclust.height.begin(), std::mem_fun(&cluster_type::disimilarity));
+		std::transform(first, last, hclust.merge.column(0).begin(), std::mem_fn(&cluster_type::parent1Id));
+		std::transform(first, last, hclust.merge.column(1).begin(), std::mem_fn(&cluster_type::parent2Id));
+		std::transform(first, last, hclust.height.begin(), std::mem_fn(&cluster_type::disimilarity));
 
 		// Swap merge entries if needed to match 'stock' hclust output
 		for (int i=0; i<hclust.merge.rows(); i++) {

--- a/inst/include/Rclusterpp/method.h
+++ b/inst/include/Rclusterpp/method.h
@@ -1,8 +1,6 @@
 #ifndef RCLUSTERP_METHOD_H
 #define RCLUSTERP_METHOD_H
 
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 namespace Rclusterpp {
 
 	
@@ -267,25 +265,25 @@ namespace Rclusterpp {
 
 	template<class Matrix>
 	Methods::DistanceFromStoredDataRows<
-		Matrix, std::pointer_to_binary_function<typename CONST_ROW&, typename CONST_ROW&, typename Matrix::RealScalar> 
+		Matrix, typename std::function<typename Matrix::RealScalar(typename CONST_ROW&, typename CONST_ROW&)> 
 	> 
 	stored_data_rows(const Matrix& m, DistanceKinds dk, double minkowski=1.0) {
 		typedef Methods::DistanceFromStoredDataRows<
-			Matrix, std::pointer_to_binary_function<typename CONST_ROW&, typename CONST_ROW&, typename Matrix::RealScalar> 
+			Matrix, typename std::function<typename Matrix::RealScalar(typename CONST_ROW&, typename CONST_ROW&)> 
 		> distancer_type;
 
 		switch (dk) {
 			default: 
         throw std::invalid_argument("Linkage or distance method not yet supported");
 			case Rclusterpp::EUCLIDEAN:
-				return distancer_type(m, std::ptr_fun(&Methods::euclidean_distance<typename CONST_ROW>));
+				return distancer_type(m, Methods::euclidean_distance<typename CONST_ROW>);
 			case Rclusterpp::MANHATTAN:
-				return distancer_type(m, std::ptr_fun(&Methods::manhattan_distance<typename CONST_ROW>));
+				return distancer_type(m, Methods::manhattan_distance<typename CONST_ROW>);
 			case Rclusterpp::MAXIMUM:
-				return distancer_type(m, std::ptr_fun(&Methods::maximum_distance<typename CONST_ROW>));
+				return distancer_type(m, Methods::maximum_distance<typename CONST_ROW>);
 			case Rclusterpp::MINKOWSKI:
 				Methods::minkowski_power_g = minkowski;
-				return distancer_type(m, std::ptr_fun(&Methods::minkowski_distance<typename CONST_ROW>));
+				return distancer_type(m, Methods::minkowski_distance<typename CONST_ROW>);
 
 		}
 	}


### PR DESCRIPTION
@bnaras @rbruggner I tried to update the C++ functions to remove the C++11 deprecation warnings and the "check" note about silenced warnings. These warnings were not generated by Eigen but by Rclusterpp code that used deprecated function wrappers. The tests still PASS, but I worry the changes will turn out to be less simple than they seem. @jtlandis Can you double check that the updates still work for you.